### PR TITLE
Allowing nikic/php-parser v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "phpstan/phpstan": "^0.12.99 || ^1.4.8",
-        "nikic/php-parser": "^4.13"
+        "nikic/php-parser": "^4.13 || ^5.0"
     },
     "license": "MIT",
     "autoload": {


### PR DESCRIPTION
There seem to be no changes required to allow projects to use PHPParser v5.

The dependency on v4 is a problem when upgrading projects to PHPUnit 11, which has some nested dependency on PHPParser v5.